### PR TITLE
Add configurable limit for max # connections per server (TVD-912)

### DIFF
--- a/memcache/memcache.go
+++ b/memcache/memcache.go
@@ -292,6 +292,7 @@ func (c *Client) getConn(addr net.Addr) (*conn, error) {
 	}
 	nc, err := c.dial(addr)
 	if err != nil {
+		c.releaseActiveConnSlot(addr)
 		return nil, err
 	}
 	cn = &conn{


### PR DESCRIPTION
This modifies the memcached client to have a configurable limit for the maximum number of connections per remote server address; it does this by using https://golang.org/pkg/sync/#Cond with its `Wait` and `Signal` functions to build a map of counting semaphores. It's not efficient for large number of memcached servers (since there is a single shared Cond across all remote addresses), but it should perform fine for a smallish number of servers (i.e. less than a dozen or so).

As implemented, the max idle connections and max active connections settings are package-wide and are both per-address limits, not global limits across all addresses.